### PR TITLE
Block Baidu Cloud P2P connection

### DIFF
--- a/dnsmasq.conf
+++ b/dnsmasq.conf
@@ -4300,10 +4300,17 @@ server=/akamaiedge.net/202.45.84.58
 server=/akadns.net/202.45.84.58
 server=/itunes.apple.com/202.45.84.58
 
-#NSFW
 address=/github.com/182.239.95.136
 address=/www.javbus.info/182.239.95.136
 address=/www.javbus.me/182.239.95.136
 address=/pics.dmm.co.jp/182.239.95.136
 address=/raw.githubusercontent.com/182.239.95.136
 address=/pics.javbus.info/182.239.95.136
+
+##Block Baidu Cloud P2P connection
+address=/bj.t.bcsp2p.baidu.com/127.0.0.1
+address=/nj.t.bcsp2p.baidu.com/127.0.0.1 
+address=/bj.t.bcsp2p.n.shifen.com/127.0.0.1
+address=/nj.t.bcsp2p.n.shifen.com/127.0.0.1
+address=/update.pan.baidu.com/127.0.0.1
+address=/update.pan.n.shifen.com/127.0.0.1


### PR DESCRIPTION
https://www.v2ex.com/t/253069 15楼 屏蔽百度云客户端使用P2P（使之使用纯的百度云HTTP节点）
